### PR TITLE
Find nearest using d3-quadtree when Hover Map (Experimental)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/d3": "^7.4.2",
         "bootstrap": "^5.3.2",
         "d3": "^7.8.5",
+        "d3-quadtree": "^3.0.1",
         "geokdbush-tk": "^2.0.3",
         "kdbush": "^4.0.2",
         "luxon": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/d3": "^7.4.2",
     "bootstrap": "^5.3.2",
     "d3": "^7.8.5",
+    "d3-quadtree": "^3.0.1",
     "geokdbush-tk": "^2.0.3",
     "kdbush": "^4.0.2",
     "luxon": "^3.4.3",


### PR DESCRIPTION
This implement d3-quadtree to find nearest coordinate from map hover. 
So far it's not quite different with KDTree, but it take more time. I think this will be use for reference instead and stick with KDTree.

![image](https://github.com/openivity/openivity.github.io/assets/3763178/5d770986-620a-48c0-b215-165ba86d6d5d)
