### PR TITLE
fix: fit service logic

### DIFF
--- a/src/components/OpenActivity.vue
+++ b/src/components/OpenActivity.vue
@@ -491,7 +491,7 @@ export default {
       for (let i = 0; i < combinedSessions.value.length; i++) {
         const ses = combinedSessions.value[i]
         for (let j = 0; j < ses.records.length; j++) {
-          if (ses.records[i].distance == null) continue
+          if (ses.records[j].distance == null) continue
           ses.records[j].distance! += prevSessionlastDistance
           lastDistance = ses.records[j].distance!
         }
@@ -547,6 +547,10 @@ export default {
       })
     },
     summarizeRecords(records: Record[], distance: number): Record[] {
+      let timestamps: string[] = []
+      let distances: number[] = []
+      let positionLats: number[] = []
+      let positionLongs: number[] = []
       let altitudes: number[] = []
       let cadences: number[] = []
       let heartRates: number[] = []
@@ -559,15 +563,15 @@ export default {
       const summarized: Record[] = []
       let cur = 0
       for (let i = 0; i < records.length; i++) {
-        const d = records[i].distance! - records[cur].distance!
+        const d = (records[i].distance ?? 0) - (records[cur].distance ?? 0)
 
         if (d > distance) {
-          let record = new Record({
-            timestamp: records[cur].timestamp,
-            distance: records[cur].distance,
-            positionLat: records[cur].positionLat,
-            positionLong: records[cur].positionLong
-          })
+          let record = new Record()
+
+          if (timestamps.length > 0) record.timestamp = timestamps[0]
+          if (distances.length > 0) record.distance = distances[0]
+          if (positionLats.length > 0) record.positionLat = positionLats[0]
+          if (positionLongs.length > 0) record.positionLong = positionLongs[0]
 
           if (altitudes.length > 0)
             record.altitude = altitudes.reduce((sum, val) => sum + val, 0) / altitudes.length
@@ -589,6 +593,10 @@ export default {
           summarized.push(record)
 
           // Reset array
+          timestamps = []
+          distances = []
+          positionLats = []
+          positionLongs = []
           altitudes = []
           cadences = []
           heartRates = []
@@ -601,30 +609,18 @@ export default {
           cur = i
         }
 
-        if (records[i].altitude) {
-          altitudes.push(records[i].altitude!)
-        }
-        if (records[i].cadence) {
-          cadences.push(records[i].cadence!)
-        }
-        if (records[i].heartRate) {
-          heartRates.push(records[i].heartRate!)
-        }
-        if (records[i].speed) {
-          speeds.push(records[i].speed!)
-        }
-        if (records[i].power) {
-          powers.push(records[i].power!)
-        }
-        if (records[i].temperature) {
-          temps.push(records[i].temperature!)
-        }
-        if (records[i].grade) {
-          grades.push(records[i].grade!)
-        }
-        if (records[i].pace) {
-          paces.push(records[i].pace!)
-        }
+        if (records[i].timestamp != null) timestamps.push(records[i].timestamp!)
+        if (records[i].distance != null) distances.push(records[i].distance!)
+        if (records[i].positionLat != null) positionLats.push(records[i].positionLat!)
+        if (records[i].positionLong != null) positionLongs.push(records[i].positionLong!)
+        if (records[i].altitude != null) altitudes.push(records[i].altitude!)
+        if (records[i].cadence != null) cadences.push(records[i].cadence!)
+        if (records[i].heartRate != null) heartRates.push(records[i].heartRate!)
+        if (records[i].speed != null) speeds.push(records[i].speed!)
+        if (records[i].power != null) powers.push(records[i].power!)
+        if (records[i].temperature != null) temps.push(records[i].temperature!)
+        if (records[i].grade != null) grades.push(records[i].grade!)
+        if (records[i].pace != null) paces.push(records[i].pace!)
       }
 
       return summarized

--- a/src/components/TheSummary.vue
+++ b/src/components/TheSummary.vue
@@ -143,8 +143,8 @@ export default {
       const summary = new Summary()
       let sports: Set<string> = new Set()
 
-      let gapSeconds: number = 0
       for (let i = 0; i < this.selectedSessions.length; i++) {
+        let gapSeconds: number = 0
         const session = this.selectedSessions[i]
         if (i > 0) {
           const prev = this.selectedSessions[i - 1]
@@ -152,7 +152,7 @@ export default {
           const prevLastTimestamp = new Date(prev.endTime).getTime()
           const currentFirstTimestamp = new Date(session.startTime).getTime()
 
-          gapSeconds += (currentFirstTimestamp - prevLastTimestamp) / 1000
+          gapSeconds = (currentFirstTimestamp - prevLastTimestamp) / 1000
         }
 
         sports.add(session.sport)

--- a/src/wasm/activity-service/activity/fit/lap.go
+++ b/src/wasm/activity-service/activity/fit/lap.go
@@ -13,9 +13,12 @@ func NewLap(mesg proto.Message) *activity.Lap {
 
 	for i := range mesg.Fields {
 		field := &mesg.Fields[i]
+
 		switch field.Num {
 		case fieldnum.LapTimestamp:
 			lap.Timestamp = datetime.ToTime(field.Value)
+		case fieldnum.LapStartTime:
+			lap.StartTime = datetime.ToTime(field.Value)
 		case fieldnum.LapTotalMovingTime:
 			totalMovingTime, ok := field.Value.(uint32)
 			if !ok || totalMovingTime == basetype.Uint32Invalid {

--- a/src/wasm/activity-service/activity/fit/listener.go
+++ b/src/wasm/activity-service/activity/fit/listener.go
@@ -1,8 +1,6 @@
 package fit
 
 import (
-	"time"
-
 	"github.com/muktihari/fit/profile/untyped/mesgnum"
 	"github.com/muktihari/fit/proto"
 	"github.com/muktihari/openactivity-fit/activity"
@@ -18,6 +16,14 @@ type Listener struct {
 	records  []*activity.Record
 	laps     []*activity.Lap
 	sessions []*activity.Session
+}
+
+type ListenerResult struct {
+	Creator  *activity.Creator
+	Timezone int
+	Records  []*activity.Record
+	Laps     []*activity.Lap
+	Sessions []*activity.Session
 }
 
 func NewListener() *Listener {
@@ -43,7 +49,11 @@ func (l *Listener) loop() {
 			}
 			l.sessions = append(l.sessions, ses)
 		case mesgnum.Lap:
-			l.laps = append(l.laps, NewLap(mesg))
+			lap := NewLap(mesg)
+			if len(l.laps) > 0 {
+				l.laps[len(l.laps)-1].EndTime = lap.StartTime
+			}
+			l.laps = append(l.laps, lap)
 		case mesgnum.Record:
 			record := NewRecord(mesg)
 			l.records = append(l.records, record)
@@ -54,74 +64,22 @@ func (l *Listener) loop() {
 
 func (l *Listener) OnMesg(mesg proto.Message) { l.mesgc <- mesg }
 
-func (l *Listener) Activity() *activity.Activity {
+func (l *Listener) Result() *ListenerResult {
 	l.WaitAndClose()
 
-	act := &activity.Activity{
-		Creator:  *l.creator,
+	r := &ListenerResult{
+		Creator:  l.creator,
 		Timezone: l.timezone,
+		Records:  l.records,
+		Laps:     l.laps,
+		Sessions: l.sessions,
 	}
-
-	// Create Sessions and Laps if not exist. This could happen only if:
-	//  - Fit file is truncated, so only some Records could be retrieved.
-	//  - Some devices may not create Lap even though it's actually required for an Activity File.
-	//    ref: https://developer.garmin.com/fit/file-types/activity
-	if len(l.sessions) == 0 {
-		if len(l.laps) == 0 {
-			lap := activity.NewLapFromRecords(l.records, activity.SportGeneric)
-			if lap != nil {
-				l.laps = append(l.laps, lap)
-			}
-			ses := activity.NewSessionFromLaps(l.laps, activity.SportGeneric)
-			if ses != nil {
-				l.sessions = append(l.sessions, ses)
-			}
-		} else {
-			ses := activity.NewSessionFromLaps(l.laps, activity.SportGeneric)
-			if ses != nil {
-				l.sessions = append(l.sessions, ses)
-			}
-		}
-	} else {
-		if len(l.laps) == 0 {
-			for i := range l.sessions { // 1 Session = 1 Lap
-				lap := activity.NewLapFromSession(l.sessions[i])
-				if lap != nil {
-					l.laps = append(l.laps, lap)
-				}
-			}
-		}
-	}
-
-	for i := range l.sessions {
-		ses := l.sessions[i]
-
-		for j := range l.laps {
-			lap := l.laps[j]
-			if isBelongToSession(lap.Timestamp, ses.StartTime, ses.EndTime) {
-				ses.Laps = append(ses.Laps, lap)
-			}
-		}
-
-		var lastRecordTimestamp time.Time
-		for j := range l.records {
-			rec := l.records[j]
-			if isBelongToSession(rec.Timestamp, ses.StartTime, ses.EndTime) {
-				ses.Records = append(ses.Records, rec)
-				lastRecordTimestamp = rec.Timestamp
-			}
-		}
-
-		l.sessions[i].EndTime = lastRecordTimestamp
-	}
-
-	act.Sessions = l.sessions
 
 	l.reset()
 
 	go l.loop()
 
-	return act
+	return r
 }
 
 func (l *Listener) reset() {
@@ -138,16 +96,4 @@ func (l *Listener) reset() {
 func (l *Listener) WaitAndClose() {
 	close(l.mesgc)
 	<-l.done
-}
-
-func isBelongToSession(timestamp, sessionStartTime, sessionEndTime time.Time) bool {
-	if timestamp.Equal(sessionStartTime) {
-		return true
-	}
-	if sessionEndTime.IsZero() && timestamp.After(sessionStartTime) { // Last Session has no EndTime
-		return true
-	} else if timestamp.After(sessionStartTime) && timestamp.Before(sessionEndTime) {
-		return true
-	}
-	return false
 }

--- a/src/wasm/activity-service/activity/fit/service.go
+++ b/src/wasm/activity-service/activity/fit/service.go
@@ -31,45 +31,195 @@ func (s *service) Decode(ctx context.Context, r io.Reader) ([]activity.Activity,
 
 	defer lis.WaitAndClose()
 
-	activities := make([]activity.Activity, 0, 1) // In most of cases, 1 fit == 1 activity
+	activities := make([]activity.Activity, 0, 1) // In most cases, 1 fit == 1 activity
 	for dec.Next() {
 		_, err := dec.DecodeWithContext(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		act := lis.Activity()
-
-		sessions := make([]*activity.Session, 0, len(act.Sessions))
-		for i := range act.Sessions {
-			ses := act.Sessions[i]
-
-			if len(ses.Records) == 0 {
-				continue
-			}
-
-			if activity.HasPace(ses.Sport) {
-				s.preprocessor.CalculatePace(ses.Sport, ses.Records)
-			}
-
-			s.preprocessor.SmoothingElev(ses.Records)
-			s.preprocessor.CalculateGrade(ses.Records)
-
-			sessions = append(sessions, ses)
-		}
-
-		act.Sessions = sessions
-
-		if len(act.Sessions) == 0 {
+		res := lis.Result()
+		act := s.convertListenerResultToActivity(res)
+		if act == nil {
 			continue
 		}
-
 		activities = append(activities, *act)
 	}
 
 	if len(activities) == 0 {
-		return nil, fmt.Errorf("fit has no activity data")
+		return nil, fmt.Errorf("fit: %w", activity.ErrNoActivity)
 	}
 
 	return activities, nil
+}
+
+func (s *service) convertListenerResultToActivity(result *ListenerResult) *activity.Activity {
+	if len(result.Records) == 0 {
+		return nil
+	}
+
+	s.sanitize(result)
+
+	act := &activity.Activity{
+		Creator:  *result.Creator,
+		Timezone: result.Timezone,
+	}
+
+	result.Records = s.preprocessor.AggregateByTimestamp(result.Records)
+
+	// Create Sessions and Laps if not exist. This could happen only if:
+	//  - Fit file is truncated, so only some Records could be retrieved.
+	//  - Some devices may not create Lap even though it's actually required for an Activity File.
+	//    ref: https://developer.garmin.com/fit/file-types/activity
+	if len(result.Sessions) == 0 {
+		if len(result.Laps) == 0 {
+			lap := activity.NewLapFromRecords(result.Records, activity.SportGeneric)
+			result.Laps = append(result.Laps, lap)
+		}
+
+		ses := activity.NewSessionFromLaps(result.Laps, activity.SportGeneric)
+		ses.Records = result.Records
+		ses.Laps = result.Laps
+		s.preprocessingRecords(ses.Records)
+		act.Sessions = []*activity.Session{ses}
+
+		return act
+	}
+
+	for i := range result.Sessions {
+		ses := result.Sessions[i]
+
+		result.Laps = ses.PutLaps(result.Laps...)
+		result.Records = ses.PutRecords(result.Records...)
+
+		if len(ses.Records) == 0 {
+			continue
+		}
+
+		s.preprocessingRecords(ses.Records)
+		s.finalizeSession(ses)
+
+		act.Sessions = append(act.Sessions, ses)
+	}
+
+	if len(result.Records) == 0 {
+		return act
+	}
+
+	// Handle remaining laps and records that don't belong any session
+	// This could happen when file is truncated or file is not properly encoded.
+	sport := activity.SportGeneric // Mark as Generic
+	s.preprocessingRecords(result.Records)
+
+	if len(result.Laps) != 0 {
+		ses := activity.NewSessionFromLaps(result.Laps, sport)
+		ses.Laps = result.Laps
+
+		result.Records = ses.PutRecords(result.Records...)
+
+		if len(ses.Records) != 0 {
+			s.finalizeSession(ses)
+			act.Sessions = append(act.Sessions, ses)
+		}
+	}
+
+	// Handle remaining records that don't belong anywhere.
+	if len(result.Records) != 0 {
+		lap := activity.NewLapFromRecords(result.Records, sport)
+		laps := []*activity.Lap{lap}
+
+		ses := activity.NewSessionFromLaps(laps, sport)
+		ses.Laps = laps
+
+		act.Sessions = append(act.Sessions, ses)
+	}
+
+	return act
+}
+
+// sanitize removes any invalid item from given result.
+func (s *service) sanitize(result *ListenerResult) {
+	if len(result.Records) == 0 {
+		return
+	}
+
+	validLaps := make([]*activity.Lap, 0)
+
+	for i := range result.Laps {
+		lap := result.Laps[i]
+
+		// Timestamp, Start Time, and Total Elapsed Time are required fields for all summary messages.
+		// If any of this field is missing, let's mark as invalid and use our own lap calculation later.
+		if lap.Timestamp.IsZero() {
+			continue
+		}
+		if lap.StartTime.IsZero() {
+			continue
+		}
+		if lap.TotalElapsedTime == 0 {
+			continue
+		}
+
+		// Most activity has 1 Lap and first Lap's StartTime should match first record's timestamp.
+		// We should not try to accommodate all bad encoding practices and this guard should be sufficient for most cases.
+		if i == 0 && !lap.StartTime.Equal(result.Records[0].Timestamp) {
+			continue
+		}
+
+		validLaps = append(validLaps, lap)
+	}
+
+	result.Laps = validLaps
+}
+
+// preprocessingRecords pre-processes records per session since 1 session corresponds to 1 sport.
+// We should not process different sports as one.
+func (s *service) preprocessingRecords(records []*activity.Record) {
+	s.preprocessor.CalculateDistanceAndSpeed(records)
+	s.preprocessor.SmoothingElev(records)
+	s.preprocessor.CalculateGrade(records)
+	if activity.HasPace(activity.SportGeneric) {
+		s.preprocessor.CalculatePace(activity.SportGeneric, records)
+	}
+}
+
+// finalizeSession finalises session by creating lap if not exist and calculating its summary as well as calculating session's summary.
+func (s *service) finalizeSession(ses *activity.Session) {
+	if len(ses.Laps) == 0 {
+		lap := activity.NewLapFromRecords(ses.Records, ses.Sport)
+		ses.Laps = append(ses.Laps, lap)
+		sesFromLaps := activity.NewSessionFromLaps(ses.Laps, ses.Sport)
+		activity.CombineSession(ses, sesFromLaps)
+		return
+	}
+
+	remainingRecords := ses.Records
+	for j := range ses.Laps {
+		lap := ses.Laps[j]
+
+		lapRecords := make([]*activity.Record, 0)
+		remainingLapRecords := make([]*activity.Record, 0)
+		for k := range remainingRecords {
+			rec := remainingRecords[k]
+
+			if lap.IsBelongToThisLap(rec.Timestamp) {
+				lapRecords = append(lapRecords, rec)
+			} else {
+				remainingLapRecords = append(remainingLapRecords, rec)
+			}
+		}
+		remainingRecords = remainingLapRecords
+
+		lapFromRecords := activity.NewLapFromRecords(lapRecords, ses.Sport)
+		activity.CombineLap(lap, lapFromRecords)
+	}
+
+	// Handle remaining records that don't belong to any lap.
+	if len(remainingRecords) != 0 {
+		lap := activity.NewLapFromRecords(remainingRecords, ses.Sport)
+		ses.Laps = append(ses.Laps, lap)
+	}
+
+	sesFromLaps := activity.NewSessionFromLaps(ses.Laps, ses.Sport)
+	activity.CombineSession(ses, sesFromLaps)
 }

--- a/src/wasm/activity-service/activity/fit/service.go
+++ b/src/wasm/activity-service/activity/fit/service.go
@@ -80,7 +80,7 @@ func (s *service) convertListenerResultToActivity(result *ListenerResult) *activ
 		ses := activity.NewSessionFromLaps(result.Laps, activity.SportGeneric)
 		ses.Records = result.Records
 		ses.Laps = result.Laps
-		s.preprocessingRecords(ses.Records)
+		s.preprocessingRecords(ses.Records, ses.Sport)
 		act.Sessions = []*activity.Session{ses}
 
 		return act
@@ -96,7 +96,7 @@ func (s *service) convertListenerResultToActivity(result *ListenerResult) *activ
 			continue
 		}
 
-		s.preprocessingRecords(ses.Records)
+		s.preprocessingRecords(ses.Records, ses.Sport)
 		s.finalizeSession(ses)
 
 		act.Sessions = append(act.Sessions, ses)
@@ -109,7 +109,7 @@ func (s *service) convertListenerResultToActivity(result *ListenerResult) *activ
 	// Handle remaining laps and records that don't belong any session
 	// This could happen when file is truncated or file is not properly encoded.
 	sport := activity.SportGeneric // Mark as Generic
-	s.preprocessingRecords(result.Records)
+	s.preprocessingRecords(result.Records, sport)
 
 	if len(result.Laps) != 0 {
 		ses := activity.NewSessionFromLaps(result.Laps, sport)
@@ -174,12 +174,12 @@ func (s *service) sanitize(result *ListenerResult) {
 
 // preprocessingRecords pre-processes records per session since 1 session corresponds to 1 sport.
 // We should not process different sports as one.
-func (s *service) preprocessingRecords(records []*activity.Record) {
+func (s *service) preprocessingRecords(records []*activity.Record, sport string) {
 	s.preprocessor.CalculateDistanceAndSpeed(records)
 	s.preprocessor.SmoothingElev(records)
 	s.preprocessor.CalculateGrade(records)
-	if activity.HasPace(activity.SportGeneric) {
-		s.preprocessor.CalculatePace(activity.SportGeneric, records)
+	if activity.HasPace(sport) {
+		s.preprocessor.CalculatePace(sport, records)
 	}
 }
 

--- a/src/wasm/activity-service/activity/gpx/service.go
+++ b/src/wasm/activity-service/activity/gpx/service.go
@@ -120,7 +120,7 @@ func (s *service) Decode(ctx context.Context, r io.Reader) ([]activity.Activity,
 	}
 
 	if len(sessions) == 0 {
-		return nil, fmt.Errorf("gpx has no activity data")
+		return nil, fmt.Errorf("gpx: %w", activity.ErrNoActivity)
 	}
 
 	act.Sessions = sessions

--- a/src/wasm/activity-service/activity/lap.go
+++ b/src/wasm/activity-service/activity/lap.go
@@ -212,3 +212,40 @@ func (l *Lap) ToMap() map[string]any {
 
 	return m
 }
+
+func (l *Lap) IsBelongToThisLap(t time.Time) bool {
+	return isBelong(t, l.StartTime, l.EndTime)
+}
+
+// CombineLap combines lap's values into targetLap.
+// Every zero value in targetLap will be replaced with the corresponding value in lap.
+func CombineLap(targetLap, lap *Lap) {
+	if targetLap == nil || lap == nil {
+		return
+	}
+
+	if targetLap.EndTime.IsZero() {
+		targetLap.EndTime = lap.EndTime
+	}
+
+	targetLap.TotalElapsedTime = kit.PickNonZeroValue(targetLap.TotalElapsedTime, lap.TotalElapsedTime)
+	targetLap.TotalMovingTime = kit.PickNonZeroValue(targetLap.TotalMovingTime, lap.TotalMovingTime)
+	targetLap.TotalDistance = kit.PickNonZeroValue(targetLap.TotalDistance, lap.TotalDistance)
+	targetLap.TotalCalories = kit.PickNonZeroValue(targetLap.TotalCalories, lap.TotalCalories)
+	targetLap.TotalAscent = kit.PickNonZeroValue(targetLap.TotalAscent, lap.TotalAscent)
+	targetLap.TotalDescent = kit.PickNonZeroValue(targetLap.TotalDescent, lap.TotalDescent)
+	targetLap.AvgSpeed = kit.PickNonZeroValuePtr(targetLap.AvgSpeed, lap.AvgSpeed)
+	targetLap.MaxSpeed = kit.PickNonZeroValuePtr(targetLap.MaxSpeed, lap.MaxSpeed)
+	targetLap.AvgHeartRate = kit.PickNonZeroValuePtr(targetLap.AvgHeartRate, lap.AvgHeartRate)
+	targetLap.MaxHeartRate = kit.PickNonZeroValuePtr(targetLap.MaxHeartRate, lap.MaxHeartRate)
+	targetLap.AvgCadence = kit.PickNonZeroValuePtr(targetLap.AvgCadence, lap.AvgCadence)
+	targetLap.MaxCadence = kit.PickNonZeroValuePtr(targetLap.MaxCadence, lap.MaxCadence)
+	targetLap.AvgPower = kit.PickNonZeroValuePtr(targetLap.AvgPower, lap.AvgPower)
+	targetLap.MaxPower = kit.PickNonZeroValuePtr(targetLap.MaxPower, lap.MaxPower)
+	targetLap.AvgTemperature = kit.PickNonZeroValuePtr(targetLap.AvgTemperature, lap.AvgTemperature)
+	targetLap.MaxTemperature = kit.PickNonZeroValuePtr(targetLap.MaxTemperature, lap.MaxTemperature)
+	targetLap.AvgAltitude = kit.PickNonZeroValuePtr(targetLap.AvgAltitude, lap.AvgAltitude)
+	targetLap.MaxAltitude = kit.PickNonZeroValuePtr(targetLap.MaxAltitude, lap.MaxAltitude)
+	targetLap.AvgPace = kit.PickNonZeroValuePtr(targetLap.AvgPace, lap.AvgPace)
+	targetLap.AvgElapsedPace = kit.PickNonZeroValuePtr(targetLap.AvgElapsedPace, lap.AvgElapsedPace)
+}

--- a/src/wasm/activity-service/activity/service.go
+++ b/src/wasm/activity-service/activity/service.go
@@ -2,7 +2,12 @@ package activity
 
 import (
 	"context"
+	"errors"
 	"io"
+)
+
+var (
+	ErrNoActivity = errors.New("no activity")
 )
 
 type Service interface {

--- a/src/wasm/activity-service/activity/session.go
+++ b/src/wasm/activity-service/activity/session.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/muktihari/openactivity-fit/accumulator"
+	"github.com/muktihari/openactivity-fit/kit"
 )
 
 type Session struct {
@@ -218,4 +219,69 @@ func (s *Session) ToMap() map[string]any {
 	}
 
 	return m
+}
+
+func (s *Session) IsBelongToThisSession(t time.Time) bool {
+	return isBelong(t, s.StartTime, s.EndTime)
+}
+
+// PutLaps puts given laps into session and return any remaining laps that doesn't belong to this session.
+func (s *Session) PutLaps(laps ...*Lap) (remainings []*Lap) {
+	remainings = make([]*Lap, 0, len(laps))
+	for j := range laps {
+		lap := laps[j]
+		if s.IsBelongToThisSession(lap.StartTime) {
+			s.Laps = append(s.Laps, lap)
+		} else {
+			remainings = append(remainings, lap)
+		}
+	}
+	return remainings
+}
+
+// PutRecords puts given records into session and return any remaining records that doesn't belong to this session.
+func (s *Session) PutRecords(records ...*Record) (remainings []*Record) {
+	remainings = make([]*Record, 0, len(records))
+	for j := range records {
+		rec := records[j]
+		if s.IsBelongToThisSession(rec.Timestamp) {
+			s.Records = append(s.Records, rec)
+		} else {
+			remainings = append(remainings, rec)
+		}
+	}
+	return remainings
+}
+
+// CombineSession combines sesssion's values into targetSession.
+// Every zero value in targetSession will be replaced with the corresponding value in session.
+func CombineSession(targetSession, session *Session) {
+	if targetSession == nil || session == nil {
+		return
+	}
+
+	if targetSession.EndTime.IsZero() {
+		targetSession.EndTime = session.EndTime
+	}
+
+	targetSession.TotalElapsedTime = kit.PickNonZeroValue(targetSession.TotalElapsedTime, session.TotalElapsedTime)
+	targetSession.TotalMovingTime = kit.PickNonZeroValue(targetSession.TotalMovingTime, session.TotalMovingTime)
+	targetSession.TotalDistance = kit.PickNonZeroValue(targetSession.TotalDistance, session.TotalDistance)
+	targetSession.TotalCalories = kit.PickNonZeroValue(targetSession.TotalCalories, session.TotalCalories)
+	targetSession.TotalAscent = kit.PickNonZeroValue(targetSession.TotalAscent, session.TotalAscent)
+	targetSession.TotalDescent = kit.PickNonZeroValue(targetSession.TotalDescent, session.TotalDescent)
+	targetSession.AvgSpeed = kit.PickNonZeroValuePtr(targetSession.AvgSpeed, session.AvgSpeed)
+	targetSession.MaxSpeed = kit.PickNonZeroValuePtr(targetSession.MaxSpeed, session.MaxSpeed)
+	targetSession.AvgHeartRate = kit.PickNonZeroValuePtr(targetSession.AvgHeartRate, session.AvgHeartRate)
+	targetSession.MaxHeartRate = kit.PickNonZeroValuePtr(targetSession.MaxHeartRate, session.MaxHeartRate)
+	targetSession.AvgCadence = kit.PickNonZeroValuePtr(targetSession.AvgCadence, session.AvgCadence)
+	targetSession.MaxCadence = kit.PickNonZeroValuePtr(targetSession.MaxCadence, session.MaxCadence)
+	targetSession.AvgPower = kit.PickNonZeroValuePtr(targetSession.AvgPower, session.AvgPower)
+	targetSession.MaxPower = kit.PickNonZeroValuePtr(targetSession.MaxPower, session.MaxPower)
+	targetSession.AvgTemperature = kit.PickNonZeroValuePtr(targetSession.AvgTemperature, session.AvgTemperature)
+	targetSession.MaxTemperature = kit.PickNonZeroValuePtr(targetSession.MaxTemperature, session.MaxTemperature)
+	targetSession.AvgAltitude = kit.PickNonZeroValuePtr(targetSession.AvgAltitude, session.AvgAltitude)
+	targetSession.MaxAltitude = kit.PickNonZeroValuePtr(targetSession.MaxAltitude, session.MaxAltitude)
+	targetSession.AvgPace = kit.PickNonZeroValuePtr(targetSession.AvgPace, session.AvgPace)
+	targetSession.AvgElapsedPace = kit.PickNonZeroValuePtr(targetSession.AvgElapsedPace, session.AvgElapsedPace)
 }

--- a/src/wasm/activity-service/activity/util.go
+++ b/src/wasm/activity-service/activity/util.go
@@ -65,13 +65,10 @@ func isBelong(timestamp, startTime, endTime time.Time) bool {
 		return true
 	}
 	if endTime.IsZero() { // Last Lap or Session has no EndTime
-		if timestamp.After(startTime) {
-			return true
-		}
-	} else {
-		if timestamp.After(startTime) || timestamp.Equal(endTime) {
-			return true
-		}
+		return timestamp.After(startTime)
 	}
-	return false
+	if timestamp.Equal(endTime) {
+		return true
+	}
+	return timestamp.After(startTime) && timestamp.Before(endTime)
 }

--- a/src/wasm/activity-service/activity/util.go
+++ b/src/wasm/activity-service/activity/util.go
@@ -2,6 +2,7 @@ package activity
 
 import (
 	"strings"
+	"time"
 	"unicode"
 
 	"golang.org/x/text/cases"
@@ -57,4 +58,20 @@ func FormatTitle(s string) string {
 	}, s)
 	s = cases.Title(language.English).String(s)
 	return s
+}
+
+func isBelong(timestamp, startTime, endTime time.Time) bool {
+	if timestamp.Equal(startTime) {
+		return true
+	}
+	if endTime.IsZero() { // Last Lap or Session has no EndTime
+		if timestamp.After(startTime) {
+			return true
+		}
+	} else {
+		if timestamp.After(startTime) || timestamp.Equal(endTime) {
+			return true
+		}
+	}
+	return false
 }

--- a/src/wasm/activity-service/kit/kit.go
+++ b/src/wasm/activity-service/kit/kit.go
@@ -1,4 +1,25 @@
 package kit
 
+import "golang.org/x/exp/constraints"
+
 // Ptr returns pointer of v
 func Ptr[T any](v T) *T { return &v }
+
+// PickNonZeroValue returns x if x != 0, otherwise return y.
+func PickNonZeroValue[T constraints.Integer | constraints.Float](x, y T) T {
+	if x == 0 {
+		return y
+	}
+	return x
+}
+
+// PickNonZeroValuePtr same as PickNonZeroValue but for pointers and return a pointer.
+func PickNonZeroValuePtr[T constraints.Integer | constraints.Float](x, y *T) *T {
+	if x == nil {
+		return y
+	}
+	if *x == 0 {
+		return y
+	}
+	return x
+}

--- a/src/wasm/activity-service/preprocessor/preprocessor.go
+++ b/src/wasm/activity-service/preprocessor/preprocessor.go
@@ -1,8 +1,6 @@
 package preprocessor
 
 import (
-	"math"
-
 	"github.com/muktihari/openactivity-fit/activity"
 	"github.com/muktihari/openactivity-fit/geomath"
 	"github.com/muktihari/openactivity-fit/kit"
@@ -192,10 +190,12 @@ func (p *Preprocessor) CalculateGrade(records []*activity.Record) {
 			run = d
 		}
 
-		grade := rise / run * 100
-		if math.IsInf(grade, 0) {
+		if rise == 0 || run == 0 {
 			continue
 		}
+
+		grade := rise / run * 100
+
 		rec.Grade = &grade
 	}
 }

--- a/src/wasm/activity-service/preprocessor/preprocessor.go
+++ b/src/wasm/activity-service/preprocessor/preprocessor.go
@@ -4,7 +4,9 @@ import (
 	"math"
 
 	"github.com/muktihari/openactivity-fit/activity"
+	"github.com/muktihari/openactivity-fit/geomath"
 	"github.com/muktihari/openactivity-fit/kit"
+	"golang.org/x/exp/constraints"
 )
 
 type Preprocessor struct {
@@ -52,6 +54,91 @@ func New(opts ...Option) *Preprocessor {
 	}
 
 	return &Preprocessor{options: options}
+}
+
+// AggregateByTimestamp aggregates fields with the same timestamp if any and return new slice of record.
+// The Fit file produced by Strava is splitting values into multiple records with the same timestamp, so
+// I think it's possible for other platforms/devices to produce similiar files.
+func (p *Preprocessor) AggregateByTimestamp(records []*activity.Record) []*activity.Record {
+	newRecords := make([]*activity.Record, 0, len(records))
+
+	for i := 0; i < len(records); i++ {
+		rec := records[i]
+
+		candidates := make([]*activity.Record, 0)
+		for j := i + 1; j < len(records); j++ {
+			next := records[j]
+			if !rec.Timestamp.Equal(next.Timestamp) {
+				i = j - 1
+				break
+			}
+			candidates = append(candidates, next)
+		}
+
+		for j := range candidates {
+			can := candidates[j]
+
+			if rec.PositionLat == nil {
+				rec.PositionLat = can.PositionLat
+			}
+			if rec.PositionLong == nil {
+				rec.PositionLong = can.PositionLong
+			}
+
+			rec.Altitude = avg(rec.Altitude, can.Altitude)
+			rec.Cadence = avg(rec.Cadence, can.Cadence)
+			rec.Speed = avg(rec.Speed, can.Speed)
+			rec.Distance = avg(rec.Distance, can.Distance)
+			rec.HeartRate = avg(rec.HeartRate, can.HeartRate)
+			rec.Power = avg(rec.Power, can.Power)
+			rec.Temperature = avg(rec.Temperature, can.Temperature)
+		}
+
+		newRecords = append(newRecords, rec)
+	}
+
+	return newRecords
+}
+
+// CalculateDistanceAndSpeed calculates distance from latitude and longitude and speed when those values are missing.
+func (p *Preprocessor) CalculateDistanceAndSpeed(records []*activity.Record) {
+	var prevRec *activity.Record
+	for i := range records {
+		rec := records[i]
+
+		// Calculate distance from two coordinates
+		var pointDistance float64
+		if rec.Distance == nil && prevRec != nil {
+			if rec.PositionLat != nil && rec.PositionLong != nil &&
+				prevRec.PositionLat != nil && prevRec.PositionLong != nil {
+
+				var prevDist float64
+				if prevRec.Distance != nil {
+					prevDist = *prevRec.Distance
+				}
+
+				pointDistance = geomath.VincentyDistance(
+					*rec.PositionLat,
+					*rec.PositionLong,
+					*prevRec.PositionLat,
+					*prevRec.PositionLong,
+				)
+
+				rec.Distance = kit.Ptr(prevDist + pointDistance)
+			}
+		}
+
+		// Speed
+		if rec.Speed == nil && pointDistance > 0 {
+			elapsed := rec.Timestamp.Sub(prevRec.Timestamp).Seconds()
+			if elapsed > 0 {
+				speed := pointDistance / elapsed
+				rec.Speed = &speed
+			}
+		}
+
+		prevRec = rec
+	}
 }
 
 // SmoothingElev smoothing elevation values using simple moving average.
@@ -128,13 +215,29 @@ func (p *Preprocessor) CalculatePace(sport string, records []*activity.Record) {
 			continue
 		}
 
-		pointDistance := ((*rec.Distance) - (*prev.Distance))
-		elapsed := rec.Timestamp.Sub(prev.Timestamp).Seconds()
-		pointDistanceInKM := pointDistance / 1000
-		if pointDistanceInKM == 0 {
-			continue
+		if rec.Speed == nil {
+			pointDistance := ((*rec.Distance) - (*prev.Distance))
+			elapsed := rec.Timestamp.Sub(prev.Timestamp).Seconds()
+			pointDistanceInKM := pointDistance / 1000
+			if pointDistanceInKM == 0 {
+				continue
+			}
+			rec.Pace = kit.Ptr(elapsed / pointDistanceInKM)
+		} else {
+			speedkph := *rec.Speed * 3.6
+			rec.Pace = kit.Ptr((1 / speedkph) * 60 * 60)
 		}
-
-		rec.Pace = kit.Ptr(elapsed / pointDistanceInKM)
 	}
+}
+
+// avg returns average of two non-nil values. Otherwise, return any non-nil value if possible.
+func avg[T constraints.Integer | constraints.Float](a, b *T) *T {
+	if a == nil {
+		return b
+	}
+	if b != nil {
+		c := T((float64(*a) + float64(*b)) / 2)
+		return &c
+	}
+	return a
 }


### PR DESCRIPTION
- [WASM] fit service now handle irregular encoded records where some values of the same timestamp spread into multiple records. 
<img width="353" alt="image" src="https://github.com/openivity/openivity.github.io/assets/15964188/77b8524c-c755-4105-a3e8-31b133f8ac10">

  Irregular records found in Strava's exported `Fit file` that was recorded directly from Strava mobile app, and exported from web like this (Export Original):
  <img width="354" alt="image" src="https://github.com/openivity/openivity.github.io/assets/15964188/85edb122-234e-4095-b522-731f27f99763">


- [WASM] fit service now fill missing value in `lap` and `session` with our service calculation.
- [WASM] fix pace calculation: if speed is present, convert speed into pace rather than manually calculating from distance and elapsed.
- [FE] summarizeRecords now handle missing distance and treat them as 0 to avoid NaN value causing graph can't be rendered.
- [FE] summary now return time elapsed with correct time gap calculation