### PR TITLE
fix: elevation extent and change 'no-data' font-size

### DIFF
--- a/src/components/ElevationGraph.vue
+++ b/src/components/ElevationGraph.vue
@@ -35,10 +35,10 @@
         </span>
       </div>
     </div>
-    <div>
-      <div v-if="!hasAltitude">No altitude data</div>
-      <div :ref="name" v-else></div>
+    <div v-if="!hasAltitude" class="h-75 d-flex text-center align-middle no-altitude-data">
+      No altitude data
     </div>
+    <div :ref="name" v-else></div>
   </div>
 </template>
 <script lang="ts">
@@ -126,9 +126,7 @@ export default {
       handler(freeze: Boolean) {
         this.hoveredRecordFreeze = freeze
         if (!freeze) {
-          const pointer = d3
-            .select(this.$refs[`${this.name}`] as HTMLElement)
-            .select('g#pointer')
+          const pointer = d3.select(this.$refs[`${this.name}`] as HTMLElement).select('g#pointer')
           pointer.style('opacity', 0)
         }
       }
@@ -196,9 +194,16 @@ export default {
 
       this.xScale = xScale
 
+      // Having an excessively small extent size is not conducive to elevation analysis,
+      // as it impedes our ability to discern the elevation differences.
+      let yExtent = d3.extent(graphRecords, (d) => d.altitude) as number[]
+      const yExtentMinSize = 100 // masl
+      const currentSize = yExtent[1] - yExtent[0]
+      if (currentSize < yExtentMinSize) yExtent[1] += yExtentMinSize - currentSize
+
       const yScale = d3
         .scaleLinear()
-        .domain(d3.extent(graphRecords, (d) => d.altitude) as Number[])
+        .domain(yExtent)
         .rangeRound([height - marginBottom, marginTop])
         .nice()
 
@@ -466,6 +471,13 @@ export default {
   padding-left: 5px;
   padding-right: 5px;
   display: inline-block;
+}
+
+.no-altitude-data {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.25rem;
 }
 
 @media (pointer: coarse) {

--- a/src/components/TheMap.vue
+++ b/src/components/TheMap.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="map-container position-relative w-100 h-100">
-    <div v-if="features?.length == 0">No map data</div>
+    <div v-if="features?.length == 0" class="no-map-data">No map data</div>
     <div v-else class="map" ref="map"></div>
     <div id="popup" class="ol-popup">
       <div class="popup-content" v-if="isIndexed">
@@ -131,7 +131,7 @@ const routeVecLayer = new VectorImageLayer({
   source: new VectorSource({ features: [] }),
   visible: true,
   style: [
-    new Style({ stroke: new Stroke({ color: 'white', width: 8 }), zIndex: -1 }), // outliner
+    new Style({ stroke: new Stroke({ color: 'white', width: 6 }), zIndex: -1 }), // outliner
     new Style({ stroke: new Stroke({ color: '#34495e', width: 4 }) })
   ]
 })
@@ -224,7 +224,7 @@ export default {
       handler(freeze: Boolean) {
         this.$emit('hoveredRecordFreeze', freeze)
       }
-    },
+    }
   },
   expose: ['showPopUpRecord'],
   methods: {
@@ -482,5 +482,9 @@ export default {
 
 .popup-content span:nth-child(2) {
   font-weight: 500;
+}
+
+.no-map-data {
+  font-size: 1.25rem;
 }
 </style>


### PR DESCRIPTION
- fix elevation extent: having an excessively small extent size is not conducive to elevation analysis, as it impedes our ability to discern the elevation differences. Set minimum extent to 100 MASL.

context: running at stadion, the track is flat, the different is no more than 1 meter.
Before 
<img width="652" alt="Screen Shot 2023-11-26 at 00 32 26" src="https://github.com/openivity/openivity.github.io/assets/15964188/73e427f0-8619-4954-a0fc-0869b9c5f282">

After
<img width="647" alt="Screen Shot 2023-11-26 at 00 32 51" src="https://github.com/openivity/openivity.github.io/assets/15964188/39d581be-e1b2-4a40-b4a8-a6a66e2b39f0">

- fix "No altitude data" and "No map data" position to  center both horizontally and vertically and change font size to 1.52 rem.
<img width="1162" alt="Screen Shot 2023-11-26 at 00 51 27" src="https://github.com/openivity/openivity.github.io/assets/15964188/b7005476-1f1d-4106-adf6-33c053a0dc7d">
