### PR TITLE
fix: total ascent/descent and total elapsed/moving time calculation

### DIFF
--- a/src/wasm/activity-service/activity/lap.go
+++ b/src/wasm/activity-service/activity/lap.go
@@ -95,15 +95,15 @@ func NewLapFromRecords(records []*Record, sport string) *Lap {
 	var totalAscent, totalDescent float64
 	for i := 0; i < len(records)-1; i++ {
 		rec := records[i]
-		if rec.Altitude == nil {
+		if rec.SmoothedAltitude == nil {
 			continue
 		}
 
 		// Find next non-nil altitude
 		for j := i + 1; j < len(records); j++ {
 			next := records[j]
-			if next.Altitude != nil {
-				delta := *next.Altitude - *rec.Altitude
+			if next.SmoothedAltitude != nil {
+				delta := *next.SmoothedAltitude - *rec.SmoothedAltitude
 				if delta > 0 {
 					totalAscent += delta
 				} else {

--- a/src/wasm/activity-service/activity/lap.go
+++ b/src/wasm/activity-service/activity/lap.go
@@ -56,7 +56,6 @@ func NewLapFromRecords(records []*Record, sport string) *Lap {
 		temperatureAccumu = new(accumulator.Accumulator[int8])
 	)
 
-	var totalAscent, totalDescent float64
 	for i := 0; i < len(records); i++ {
 		rec := records[i]
 
@@ -67,30 +66,51 @@ func NewLapFromRecords(records []*Record, sport string) *Lap {
 		heartRateAccumu.Collect(rec.HeartRate)
 		powerAccumu.Collect(rec.Power)
 		temperatureAccumu.Collect(rec.Temperature)
+	}
 
-		if i == 0 {
+	// Calculate Total Elapsed and Total Moving Time
+	for i := 0; i < len(records); i++ {
+		rec := records[i]
+		if rec.Timestamp.IsZero() {
 			continue
 		}
 
-		prev := records[i-1]
+		// Find next non-zero timestamp
+		for j := i + 1; j < len(records); j++ {
+			next := records[j]
+			if !next.Timestamp.IsZero() {
+				delta := next.Timestamp.Sub(rec.Timestamp).Seconds()
+				lap.TotalElapsedTime += delta
 
-		// Calculate Total Elapsed and Total Moving Time
-		if rec.Distance != nil && prev.Distance != nil {
-			timeDiff := rec.Timestamp.Sub(prev.Timestamp).Seconds()
-			lap.TotalElapsedTime += timeDiff
-
-			if IsConsideredMoving(sport, rec.Speed) {
-				lap.TotalMovingTime += timeDiff
+				if IsConsideredMoving(sport, rec.Speed) {
+					lap.TotalMovingTime += delta
+				}
+				i = j - 1 // move cursor
+				break
 			}
 		}
+	}
 
-		// Calculate Total Ascent and Total Descent
-		if rec.Altitude != nil && prev.Altitude != nil {
-			delta := *rec.Altitude - *prev.Altitude
-			if delta > 0 {
-				totalAscent += delta
-			} else {
-				totalDescent += math.Abs(delta)
+	// Calculate Total Ascent and Total Descent
+	var totalAscent, totalDescent float64
+	for i := 0; i < len(records)-1; i++ {
+		rec := records[i]
+		if rec.Altitude == nil {
+			continue
+		}
+
+		// Find next non-nil altitude
+		for j := i + 1; j < len(records); j++ {
+			next := records[j]
+			if next.Altitude != nil {
+				delta := *next.Altitude - *rec.Altitude
+				if delta > 0 {
+					totalAscent += delta
+				} else {
+					totalDescent += math.Abs(delta)
+				}
+				i = j - 1 // move cursor
+				break
 			}
 		}
 	}


### PR DESCRIPTION
With previous algorithm, when we have these following records pattern, these records will be skipped entirely

```go
records[0].altitude = 100
records[1].altitude = nil
records[2].altitude = 101
records[3].altitude = nil
records[4].altitude = 102
records[5].altitude = nil
```

Previous algorithm: 
- When the `i = 0 and i+1 = 1`, we skipped the calculation, then `i = 1 and i+1 = 2`, we also skipped it again.

 To mitigate this records pattern, we need to compare it to the next non-nil value, then move the cursor to that next record.