### PR TITLE
Apply caret model style to all modules

### DIFF
--- a/src/components/AreaGraph.vue
+++ b/src/components/AreaGraph.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="col-12 h-100">
     <div
-      class="line-graph-hover row m-0"
+      class="line-graph-hover row m-0 collapsible"
       style="cursor: pointer"
       data-bs-toggle="collapse"
       v-bind:data-bs-target="`#${graphContainerName}`"
@@ -10,8 +10,7 @@
     >
       <div class="d-flex pb-1 pe-2">
         <h6 class="title mb-0 col text-start">
-          <i class="fa-solid fa-caret-down when-opened"></i>
-          <i class="fa-solid fa-caret-right when-closed"></i>
+          <i class="fa-solid fa-caret-right collapse-indicator"></i>
           {{ name }}
           <i :class="['fa-solid', icon]"></i>
         </h6>
@@ -494,10 +493,5 @@ export default {
 
 .graph-summary > div:nth-child(odd) {
   box-shadow: 0px 0.5px grey;
-}
-
-.collapsed > div > h6 > .fa-caret-down,
-:not(.collapsed) > div > h6 > .fa-caret-right {
-  display: none;
 }
 </style>

--- a/src/components/TheLap.vue
+++ b/src/components/TheLap.vue
@@ -2,7 +2,7 @@
   <div class="col-12 h-100" v-if="laps?.length > 0">
     <div v-for="(lap, index) in laps" :key="index">
       <div
-        class="tab row m-0 mt-2 pt-2"
+        class="tab row m-0 mt-2 pt-2 collapsible"
         style="cursor: pointer"
         data-bs-toggle="collapse"
         v-bind:data-bs-target="'#laps-' + index"
@@ -12,8 +12,7 @@
         <div class="row text-start">
           <div class="col-auto d-inline-block" style="height: 50px">
             <h6 style="text-align: left">
-              <i class="fa-solid fa-caret-down"></i>
-              <i class="fa-solid fa-caret-right"></i>
+              <i class="fa-solid fa-caret-right collapse-indicator"></i>
               <span class="px-1">Lap {{ index + 1 }}</span>
             </h6>
           </div>
@@ -139,10 +138,5 @@ export default {
 
 .calories {
   background-color: var(--color-background-soft);
-}
-
-.collapsed > div > div > h6 > .fa-caret-down,
-:not(.collapsed) > div > div > h6 > .fa-caret-right {
-  display: none;
 }
 </style>

--- a/src/components/TheSession.vue
+++ b/src/components/TheSession.vue
@@ -2,7 +2,7 @@
   <div class="col-12 h-100" v-if="sessions?.length > 0">
     <div v-for="(session, index) in sessions" :key="index">
       <div
-        class="tab row m-0 mt-2 pt-2"
+        class="tab row m-0 mt-2 pt-2 collapsible"
         style="cursor: pointer"
         data-bs-toggle="collapse"
         v-bind:data-bs-target="'#sessions-' + index"
@@ -12,8 +12,7 @@
         <div class="row text-start">
           <div class="col-auto d-inline-block" style="height: 50px">
             <h6 style="text-align: left" class="mb-0">
-              <i class="fa-solid fa-caret-down"></i>
-              <i class="fa-solid fa-caret-right"></i>
+              <i class="fa-solid fa-caret-right collapse-indicator"></i>
               <span class="px-1">Ses {{ index + 1 }}</span>
             </h6>
             <span>{{ session.sport }}</span>
@@ -146,10 +145,5 @@ export default {
 
 .calories {
   background-color: var(--color-background-soft);
-}
-
-.collapsed > div > div > h6 > .fa-caret-down,
-:not(.collapsed) > div > div > h6 > .fa-caret-right {
-  display: none;
 }
 </style>


### PR DESCRIPTION
if default collapse content is showing 
on collapse content
- add class `show` & `collapse`
we add on collapse
- add class `collapsible`
and on caret-right
- add class `collapse-indicator`

if default collapse content is not-showing
on collapse content
- add class `collapse`
we add on collapse
- add class `collapsible` & `collapsed`
and on caret-right
- add class `collapse-indicator`