### PR TITLE
chore: bump FIT SDK for Go version from v0.1.5 to v0.2.0

### DIFF
--- a/src/wasm/activity-service/go.mod
+++ b/src/wasm/activity-service/go.mod
@@ -3,7 +3,7 @@ module github.com/muktihari/openactivity-fit
 go 1.20
 
 require (
-	github.com/muktihari/fit v0.1.5
+	github.com/muktihari/fit v0.2.0
 	golang.org/x/text v0.13.0
 )
 

--- a/src/wasm/activity-service/go.sum
+++ b/src/wasm/activity-service/go.sum
@@ -1,8 +1,6 @@
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/muktihari/fit v0.1.4 h1:mcEpiTFpIIAUUuTcOtMck/xOtpsK7BgozeOW1+/j0XQ=
-github.com/muktihari/fit v0.1.4/go.mod h1:Y0S4wUVf9Kpv8IMwP31FGid7WtifT36mg+WMa8a4LqM=
-github.com/muktihari/fit v0.1.5 h1:peRh0nJcWO1S8UolAptqfn0Jf+v7MEIR8OhsYPAy7Ao=
-github.com/muktihari/fit v0.1.5/go.mod h1:Y0S4wUVf9Kpv8IMwP31FGid7WtifT36mg+WMa8a4LqM=
+github.com/muktihari/fit v0.2.0 h1:szPJwoZUtPePNp9vQiSgqB2pIPHQt6DrUMRse/xz6KI=
+github.com/muktihari/fit v0.2.0/go.mod h1:Y0S4wUVf9Kpv8IMwP31FGid7WtifT36mg+WMa8a4LqM=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=


### PR DESCRIPTION
Changes that might affect this app:
- Garmin has release SDK version `21.126` on Nov 21 2023 with additional manufacturer and garmin product list, this new FIT SDK for Go version v0.2.0 have been sync with that changes.
- Fix on handling invalid values on float32 and float64 types.

Release notes: 
- https://github.com/muktihari/fit/releases/tag/v0.1.6
- https://github.com/muktihari/fit/releases/tag/v0.2.0