### PR TITLE
fix(no-ticket): missing information in lap and session

### DIFF
--- a/src/wasm/activity-service/activity/fit/service.go
+++ b/src/wasm/activity-service/activity/fit/service.go
@@ -98,6 +98,14 @@ func (s *service) convertListenerResultToActivity(result *ListenerResult) *activ
 		act.Sessions = []*activity.Session{ses}
 
 		return act
+	} else if len(result.Laps) == 0 {
+		// Some devices may only create sessions but no laps, to ensure we don't lose any summary data in session
+		// since there are information that only available in session but not in records.
+		// Let's create laps from sessions, 1 session should at least have 1 lap.
+		result.Laps = make([]*activity.Lap, len(result.Sessions))
+		for i := range result.Sessions {
+			result.Laps[i] = activity.NewLapFromSession(result.Sessions[i])
+		}
 	}
 
 	for i := range result.Sessions {

--- a/src/wasm/activity-service/activity/session.go
+++ b/src/wasm/activity-service/activity/session.go
@@ -63,6 +63,7 @@ func NewSessionFromLaps(laps []*Lap, sport string) *Session {
 		totalDistanceAccumu    = new(accumulator.Accumulator[float64])
 		totalAscentAccumu      = new(accumulator.Accumulator[uint16])
 		totalDescentAccumu     = new(accumulator.Accumulator[uint16])
+		totalCaloriesAccumu    = new(accumulator.Accumulator[uint16])
 		speedAvgAccumu         = new(accumulator.Accumulator[float64])
 		speedMaxAccumu         = new(accumulator.Accumulator[float64])
 		altitudeAvgAccumu      = new(accumulator.Accumulator[float64])
@@ -85,6 +86,7 @@ func NewSessionFromLaps(laps []*Lap, sport string) *Session {
 		totalDistanceAccumu.Collect(&lap.TotalDistance)
 		totalAscentAccumu.Collect(&lap.TotalAscent)
 		totalDescentAccumu.Collect(&lap.TotalDescent)
+		totalCaloriesAccumu.Collect(&lap.TotalCalories)
 		speedAvgAccumu.Collect(lap.AvgSpeed)
 		speedMaxAccumu.Collect(lap.MaxSpeed)
 		altitudeAvgAccumu.Collect(lap.AvgAltitude)
@@ -113,6 +115,9 @@ func NewSessionFromLaps(laps []*Lap, sport string) *Session {
 	}
 	if value := totalDescentAccumu.Sum(); value != nil {
 		ses.TotalDescent = *value
+	}
+	if value := totalCaloriesAccumu.Sum(); value != nil {
+		ses.TotalCalories = *value
 	}
 
 	ses.AvgSpeed = speedAvgAccumu.Avg()


### PR DESCRIPTION
- TotalCalories was not calculated in Session that was created from Laps
- For FIT files that have no laps at all, we should create it from session so we do not lose any information, for example total calories only available in session and lap but not in records,  we can't aggregate the value from records. (Note: 1 Session should at least have 1 Lap)