### PR TITLE
chore: bump fit sdk version from 0.2.0 to 0.3.1

### DIFF
--- a/src/wasm/activity-service/go.mod
+++ b/src/wasm/activity-service/go.mod
@@ -3,7 +3,7 @@ module github.com/muktihari/openactivity-fit
 go 1.20
 
 require (
-	github.com/muktihari/fit v0.2.0
+	github.com/muktihari/fit v0.3.1
 	golang.org/x/text v0.13.0
 )
 

--- a/src/wasm/activity-service/go.sum
+++ b/src/wasm/activity-service/go.sum
@@ -1,6 +1,8 @@
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/muktihari/fit v0.2.0 h1:szPJwoZUtPePNp9vQiSgqB2pIPHQt6DrUMRse/xz6KI=
 github.com/muktihari/fit v0.2.0/go.mod h1:Y0S4wUVf9Kpv8IMwP31FGid7WtifT36mg+WMa8a4LqM=
+github.com/muktihari/fit v0.3.1 h1:BKwL9Vc5LixzAHtOANrmxbbVquKvRtl+PvuFsopN0N8=
+github.com/muktihari/fit v0.3.1/go.mod h1:Y0S4wUVf9Kpv8IMwP31FGid7WtifT36mg+WMa8a4LqM=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=


### PR DESCRIPTION
perf and memory optimization