### PR TITLE
fix: fit sdk version bump and update related bugs

### DIFF
--- a/src/wasm/activity-service/activity/fit/lap.go
+++ b/src/wasm/activity-service/activity/fit/lap.go
@@ -154,7 +154,7 @@ func convertLapToMesg(lap *activity.Lap) proto.Message {
 	}
 	if lap.TotalDistance != 0 {
 		field := factory.CreateField(mesgnum.Lap, fieldnum.LapTotalDistance)
-		field.Value = scaleoffset.DiscardAny(lap.AvgAltitude, field.Type.BaseType(), field.Scale, field.Offset)
+		field.Value = scaleoffset.DiscardAny(lap.TotalDistance, field.Type.BaseType(), field.Scale, field.Offset)
 		mesg.Fields = append(mesg.Fields, field)
 	}
 	if lap.TotalAscent != 0 {
@@ -224,12 +224,12 @@ func convertLapToMesg(lap *activity.Lap) proto.Message {
 	}
 	if lap.AvgAltitude != nil {
 		field := factory.CreateField(mesgnum.Lap, fieldnum.LapAvgAltitude)
-		field.Value = scaleoffset.DiscardAny(lap.AvgAltitude, field.Type.BaseType(), field.Scale, field.Offset)
+		field.Value = scaleoffset.DiscardAny(*lap.AvgAltitude, field.Type.BaseType(), field.Scale, field.Offset)
 		mesg.Fields = append(mesg.Fields, field)
 	}
 	if lap.MaxAltitude != nil {
 		field := factory.CreateField(mesgnum.Lap, fieldnum.LapMaxAltitude)
-		field.Value = scaleoffset.DiscardAny(lap.MaxAltitude, field.Type.BaseType(), field.Scale, field.Offset)
+		field.Value = scaleoffset.DiscardAny(*lap.MaxAltitude, field.Type.BaseType(), field.Scale, field.Offset)
 		mesg.Fields = append(mesg.Fields, field)
 	}
 

--- a/src/wasm/activity-service/activity/fit/session.go
+++ b/src/wasm/activity-service/activity/fit/session.go
@@ -270,12 +270,12 @@ func convertSessionToMesg(ses *activity.Session) proto.Message {
 	}
 	if ses.AvgAltitude != nil {
 		field := factory.CreateField(mesgnum.Session, fieldnum.SessionAvgAltitude)
-		field.Value = scaleoffset.DiscardAny(ses.AvgAltitude, field.Type.BaseType(), field.Scale, field.Offset)
+		field.Value = scaleoffset.DiscardAny(*ses.AvgAltitude, field.Type.BaseType(), field.Scale, field.Offset)
 		mesg.Fields = append(mesg.Fields, field)
 	}
 	if ses.MaxAltitude != nil {
 		field := factory.CreateField(mesgnum.Session, fieldnum.SessionMaxAltitude)
-		field.Value = scaleoffset.DiscardAny(ses.MaxAltitude, field.Type.BaseType(), field.Scale, field.Offset)
+		field.Value = scaleoffset.DiscardAny(*ses.MaxAltitude, field.Type.BaseType(), field.Scale, field.Offset)
 		mesg.Fields = append(mesg.Fields, field)
 	}
 

--- a/src/wasm/activity-service/go.mod
+++ b/src/wasm/activity-service/go.mod
@@ -3,7 +3,7 @@ module github.com/muktihari/openactivity-fit
 go 1.20
 
 require (
-	github.com/muktihari/fit v0.4.0
+	github.com/muktihari/fit v0.4.1
 	golang.org/x/text v0.13.0
 )
 

--- a/src/wasm/activity-service/go.sum
+++ b/src/wasm/activity-service/go.sum
@@ -1,10 +1,6 @@
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/muktihari/fit v0.2.0 h1:szPJwoZUtPePNp9vQiSgqB2pIPHQt6DrUMRse/xz6KI=
-github.com/muktihari/fit v0.2.0/go.mod h1:Y0S4wUVf9Kpv8IMwP31FGid7WtifT36mg+WMa8a4LqM=
-github.com/muktihari/fit v0.3.1 h1:BKwL9Vc5LixzAHtOANrmxbbVquKvRtl+PvuFsopN0N8=
-github.com/muktihari/fit v0.3.1/go.mod h1:Y0S4wUVf9Kpv8IMwP31FGid7WtifT36mg+WMa8a4LqM=
-github.com/muktihari/fit v0.4.0 h1:M/j3JOr++Dr94sxEe/jKYmknJyyH5PnoyA0vDTKo7FA=
-github.com/muktihari/fit v0.4.0/go.mod h1:Y0S4wUVf9Kpv8IMwP31FGid7WtifT36mg+WMa8a4LqM=
+github.com/muktihari/fit v0.4.1 h1:BKMynvuSvjKWtXE+HeqtDL8KqVP6GDyT5x0Wv7fQqKk=
+github.com/muktihari/fit v0.4.1/go.mod h1:Y0S4wUVf9Kpv8IMwP31FGid7WtifT36mg+WMa8a4LqM=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=

--- a/src/wasm/activity-service/service/result/decode.go
+++ b/src/wasm/activity-service/service/result/decode.go
@@ -3,6 +3,7 @@ package result
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -21,7 +22,7 @@ var _ json.Marshaler = &Decode{}
 
 func (d *Decode) MarshalJSON() ([]byte, error) {
 	if d.Err != nil {
-		return []byte("{\"err\":\"" + d.Err.Error() + "\"}"), nil
+		return []byte(fmt.Sprintf("{%q:%q}", "err", d.Err)), nil
 	}
 
 	begin := time.Now()

--- a/src/wasm/activity-service/service/result/encode.go
+++ b/src/wasm/activity-service/service/result/encode.go
@@ -3,6 +3,7 @@ package result
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"time"
 )
@@ -22,7 +23,7 @@ var _ json.Marshaler = &Encode{}
 
 func (e *Encode) MarshalJSON() ([]byte, error) {
 	if e.Err != nil {
-		return []byte("{\"err\":\"" + e.Err.Error() + "\"}"), nil
+		return []byte(fmt.Sprintf("{%q:%q}", "err", e.Err)), nil
 	}
 
 	begin := time.Now()


### PR DESCRIPTION
- Update FIT SDK for Go from v0.4.0 to v0.4.1: 
   - In previous version, there is bug that when a type mismatch is silently skipped making it a false-negative. 
   - Performance improvement on encoding.
- Update bugs that was silently there but now has comes into surface after the SDK update.
- Update minor bug on marshal json on error.

ref: 
- fit sdk changelogs https://github.com/muktihari/fit/releases/tag/v0.4.1