### PR TITLE
chore: bump fit sdk version from v0.19.0 into v0.19.1

### DIFF
--- a/src/wasm/activity-service/go.mod
+++ b/src/wasm/activity-service/go.mod
@@ -3,7 +3,7 @@ module github.com/openivity/activity-service
 go 1.20
 
 require (
-	github.com/muktihari/fit v0.19.0
+	github.com/muktihari/fit v0.19.1
 	golang.org/x/text v0.15.0
 )
 

--- a/src/wasm/activity-service/go.sum
+++ b/src/wasm/activity-service/go.sum
@@ -1,7 +1,7 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/muktihari/fit v0.19.0 h1:VoF/diZ4c0E4JPlNXePZC6Ih7kwxDRv5IxNukyTnKS4=
-github.com/muktihari/fit v0.19.0/go.mod h1:h+rmkwcRvbq4WlTYXgjw/AAOqipfwyULT32lM/DIixo=
+github.com/muktihari/fit v0.19.1 h1:YtNmIqrdQu4CSFM2ngwxyc93RLg3q0W1satCb3bmDVw=
+github.com/muktihari/fit v0.19.1/go.mod h1:h+rmkwcRvbq4WlTYXgjw/AAOqipfwyULT32lM/DIixo=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=


### PR DESCRIPTION
- Minor fix on sorting timestamp for `Course` and `Set` messages since these legacy messages have different `timestamp_id`, most activity files don't have these messages but just in case.