### PR TITLE
chore: update workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,15 +13,15 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
 
-      - name: Set up Go 🔧 # Currently using wasm_exec.js go-version 1.20.8
-        uses: actions/setup-go@v4
+      - name: Set up Go 🔧 # Build using latest Go version (stable)
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.20.8'
+          go-version: 'stable'
 
       - name: Set up Node 🔧
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20 # LTS (May 2024 - April 2026)
           cache: 'npm'
 
       - name: Install dependencies
@@ -29,6 +29,8 @@ jobs:
 
       - name: Build Wasm & Web 🔧
         run: |
+          cp $(go env GOROOT)/misc/wasm/wasm_exec.js src/assets/wasm/wasm_exec.js
+
           npm ci
           npm run build-wasm
           npm run build-only

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,15 +13,15 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
 
-      - name: Set up Go 🔧 # Currently using wasm_exec.js go-version 1.20.8
-        uses: actions/setup-go@v4
+      - name: Set up Go 🔧 # Build using latest Go version (stable)
+        uses: actions/setup-go@v5
         with:
-          go-version: '>=1.20.8'
+          go-version: 'stable'
 
       - name: Set up Node 🔧
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20 # LTS (May 2024 - April 2026)
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
- Build WebAssembly using latest version of Go. Go promise: "Old Go code will always run on newer version". This way we will always get the best version of Go with latest security patch.
- Bump Node version from v18 to v20 since version 18 will be deprecated next year. I use Node v20 locally, our code run just fine.