### PR TITLE
fix: export GPX and TCX wrong DeviceName

### DIFF
--- a/src/components/ToolDeviceSelector.vue
+++ b/src/components/ToolDeviceSelector.vue
@@ -267,10 +267,11 @@ export default {
       if (device.manufacturerId != undefined) this.deviceName = device.label
     },
     updateSelectedByDeviceName(deviceName: string) {
-      const device = this.deviceMappingForGpxTcx.get(deviceName.toLocaleLowerCase())
-      if (device != undefined) {
-        this.selected = device
+      let device = this.deviceMappingForGpxTcx.get(deviceName.toLocaleLowerCase())
+      if (device == undefined) {
+        device = new DeviceOption({ label: deviceName })
       }
+      this.selected = device
     }
   },
   mounted() {

--- a/src/wasm/activity-service/go.mod
+++ b/src/wasm/activity-service/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/muktihari/fit v0.20.1
-	github.com/muktihari/xmltokenizer v0.0.0-20240614025545-7e2f70738015
+	github.com/muktihari/xmltokenizer v0.0.2
 	golang.org/x/text v0.16.0
 )
 

--- a/src/wasm/activity-service/go.sum
+++ b/src/wasm/activity-service/go.sum
@@ -6,6 +6,8 @@ github.com/muktihari/xmltokenizer v0.0.0-20240614023440-d3856c83414f h1:MG4JH00g
 github.com/muktihari/xmltokenizer v0.0.0-20240614023440-d3856c83414f/go.mod h1:yTxhndrcpmZEPYqQGSN51MwkzPQgGSkRpqW5ZFBpdF0=
 github.com/muktihari/xmltokenizer v0.0.0-20240614025545-7e2f70738015 h1:DLcr3PcEvjkx39PkXNJClDVF+LsmW4WVaLULk7JrQmk=
 github.com/muktihari/xmltokenizer v0.0.0-20240614025545-7e2f70738015/go.mod h1:yTxhndrcpmZEPYqQGSN51MwkzPQgGSkRpqW5ZFBpdF0=
+github.com/muktihari/xmltokenizer v0.0.2 h1:SNOqhOVaAiXo3DA7X02RFVT5lkQph1juHASAU2vr9W0=
+github.com/muktihari/xmltokenizer v0.0.2/go.mod h1:yTxhndrcpmZEPYqQGSN51MwkzPQgGSkRpqW5ZFBpdF0=
 golang.org/x/exp v0.0.0-20240531132922-fd00a4e0eefc h1:O9NuF4s+E/PvMIy+9IUZB9znFwUIXEWSstNjek6VpVg=
 golang.org/x/exp v0.0.0-20240531132922-fd00a4e0eefc/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8 h1:yixxcjnhBmY0nkL253HFVIm0JsFHwrHdT3Yh6szTnfY=


### PR DESCRIPTION
- When user changes the deviceName manually (text input), we will try to match deviceName from user's input into our database so we can get a valid `manufacturerId` and `ProductId` in case user wants to export to FIT later, however we do not specify a fallback when the mapping value is not found, for GPX and TCX only the deviceName is required.
- This is not related to the issue, but let's just include it: bump `xmltokenizer` to `v0.0.2`

Let's do patch release after this 😅