### PR TITLE
fix: allow enhanced fields

### DIFF
--- a/src/wasm/activity-service/.gitignore
+++ b/src/wasm/activity-service/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/src/wasm/activity-service/activity/lap.go
+++ b/src/wasm/activity-service/activity/lap.go
@@ -342,16 +342,27 @@ func (l *Lap) MarshalAppendJSON(b []byte) []byte {
 		b = strconv.AppendUint(b, uint64(l.TotalCalories), 10)
 		b = append(b, ',')
 	}
-	if l.AvgSpeed != basetype.Uint16Invalid {
+
+	avgSpeed := l.AvgSpeedScaled()
+	if math.IsNaN(avgSpeed) {
+		avgSpeed = l.EnhancedAvgSpeedScaled()
+	}
+	if !math.IsNaN(avgSpeed) {
 		b = append(b, `"avgSpeed":`...)
-		b = strconv.AppendFloat(b, l.AvgSpeedScaled(), 'g', -1, 64)
+		b = strconv.AppendFloat(b, avgSpeed, 'g', -1, 64)
 		b = append(b, ',')
 	}
-	if l.MaxSpeed != basetype.Uint16Invalid {
+
+	maxSpeed := l.MaxSpeedScaled()
+	if math.IsNaN(maxSpeed) {
+		maxSpeed = l.EnhancedMaxSpeedScaled()
+	}
+	if !math.IsNaN(maxSpeed) {
 		b = append(b, `"maxSpeed":`...)
-		b = strconv.AppendFloat(b, l.MaxSpeedScaled(), 'g', -1, 64)
+		b = strconv.AppendFloat(b, maxSpeed, 'g', -1, 64)
 		b = append(b, ',')
 	}
+
 	if l.AvgHeartRate != basetype.Uint8Invalid {
 		b = append(b, `"avgHeartRate":`...)
 		b = strconv.AppendUint(b, uint64(l.AvgHeartRate), 10)
@@ -392,14 +403,24 @@ func (l *Lap) MarshalAppendJSON(b []byte) []byte {
 		b = strconv.AppendInt(b, int64(l.MaxTemperature), 10)
 		b = append(b, ',')
 	}
-	if l.AvgAltitude != basetype.Uint16Invalid {
+
+	avgAltitude := l.AvgAltitudeScaled()
+	if math.IsNaN(avgAltitude) {
+		avgAltitude = l.EnhancedAvgAltitudeScaled()
+	}
+	if !math.IsNaN(avgAltitude) {
 		b = append(b, `"avgAltitude":`...)
-		b = strconv.AppendFloat(b, l.AvgAltitudeScaled(), 'g', -1, 64)
+		b = strconv.AppendFloat(b, avgAltitude, 'g', -1, 64)
 		b = append(b, ',')
 	}
-	if l.MaxAltitude != basetype.Uint16Invalid {
+
+	maxAltitude := l.MaxAltitudeScaled()
+	if math.IsNaN(maxAltitude) {
+		maxAltitude = l.EnhancedMaxAltitudeScaled()
+	}
+	if !math.IsNaN(maxAltitude) {
 		b = append(b, `"maxAltitude":`...)
-		b = strconv.AppendFloat(b, l.MaxAltitudeScaled(), 'g', -1, 64)
+		b = strconv.AppendFloat(b, maxAltitude, 'g', -1, 64)
 		b = append(b, ',')
 	}
 

--- a/src/wasm/activity-service/activity/record.go
+++ b/src/wasm/activity-service/activity/record.go
@@ -70,11 +70,20 @@ func (r *Record) MarshalAppendJSON(b []byte) []byte {
 		b = strconv.AppendFloat(b, r.DistanceScaled(), 'g', -1, 64)
 		b = append(b, ',')
 	}
-	if !math.IsNaN(r.SmoothedAltitude) {
+
+	altitude := r.SmoothedAltitude
+	if math.IsNaN(altitude) {
+		altitude = r.AltitudeScaled()
+	}
+	if math.IsNaN(altitude) {
+		altitude = r.EnhancedAltitudeScaled()
+	}
+	if !math.IsNaN(altitude) {
 		b = append(b, `"altitude":`...)
-		b = strconv.AppendFloat(b, r.SmoothedAltitude, 'g', -1, 64)
+		b = strconv.AppendFloat(b, altitude, 'g', -1, 64)
 		b = append(b, ',')
 	}
+
 	if r.HeartRate != basetype.Uint8Invalid {
 		b = append(b, `"heartRate":`...)
 		b = strconv.AppendUint(b, uint64(r.HeartRate), 10)
@@ -85,11 +94,17 @@ func (r *Record) MarshalAppendJSON(b []byte) []byte {
 		b = strconv.AppendUint(b, uint64(r.Cadence), 10)
 		b = append(b, ',')
 	}
-	if r.Speed != basetype.Uint16Invalid {
+
+	speed := r.SpeedScaled()
+	if math.IsNaN(speed) {
+		speed = r.EnhancedAltitudeScaled()
+	}
+	if !math.IsNaN(speed) {
 		b = append(b, `"speed":`...)
-		b = strconv.AppendFloat(b, r.SpeedScaled(), 'g', -1, 64)
+		b = strconv.AppendFloat(b, speed, 'g', -1, 64)
 		b = append(b, ',')
 	}
+
 	if r.Power != basetype.Uint16Invalid {
 		b = append(b, `"power":`...)
 		b = strconv.AppendUint(b, uint64(r.Power), 10)

--- a/src/wasm/activity-service/activity/session.go
+++ b/src/wasm/activity-service/activity/session.go
@@ -452,16 +452,27 @@ func (s *Session) MarshalAppendJSON(b []byte) []byte {
 		b = strconv.AppendUint(b, uint64(s.TotalCalories), 10)
 		b = append(b, ',')
 	}
-	if s.AvgSpeed != basetype.Uint16Invalid {
+
+	avgSpeed := s.AvgSpeedScaled()
+	if math.IsNaN(avgSpeed) {
+		avgSpeed = s.EnhancedAvgSpeedScaled()
+	}
+	if !math.IsNaN(avgSpeed) {
 		b = append(b, `"avgSpeed":`...)
-		b = strconv.AppendFloat(b, s.AvgSpeedScaled(), 'g', -1, 64)
+		b = strconv.AppendFloat(b, avgSpeed, 'g', -1, 64)
 		b = append(b, ',')
 	}
-	if s.MaxSpeed != basetype.Uint16Invalid {
+
+	maxSpeed := s.MaxSpeedScaled()
+	if math.IsNaN(maxSpeed) {
+		maxSpeed = s.EnhancedMaxSpeedScaled()
+	}
+	if !math.IsNaN(maxSpeed) {
 		b = append(b, `"maxSpeed":`...)
-		b = strconv.AppendFloat(b, s.MaxSpeedScaled(), 'g', -1, 64)
+		b = strconv.AppendFloat(b, maxSpeed, 'g', -1, 64)
 		b = append(b, ',')
 	}
+
 	if s.AvgHeartRate != basetype.Uint8Invalid {
 		b = append(b, `"avgHeartRate":`...)
 		b = strconv.AppendUint(b, uint64(s.AvgHeartRate), 10)
@@ -502,14 +513,24 @@ func (s *Session) MarshalAppendJSON(b []byte) []byte {
 		b = strconv.AppendInt(b, int64(s.MaxTemperature), 10)
 		b = append(b, ',')
 	}
-	if s.AvgAltitude != basetype.Uint16Invalid {
+
+	avgAltitude := s.AvgAltitudeScaled()
+	if math.IsNaN(avgAltitude) {
+		avgAltitude = s.EnhancedAvgAltitudeScaled()
+	}
+	if !math.IsNaN(avgAltitude) {
 		b = append(b, `"avgAltitude":`...)
-		b = strconv.AppendFloat(b, s.AvgAltitudeScaled(), 'g', -1, 64)
+		b = strconv.AppendFloat(b, avgAltitude, 'g', -1, 64)
 		b = append(b, ',')
 	}
-	if s.MaxAltitude != basetype.Uint16Invalid {
+
+	maxAltitude := s.MaxAltitudeScaled()
+	if math.IsNaN(maxAltitude) {
+		maxAltitude = s.EnhancedMaxAltitudeScaled()
+	}
+	if !math.IsNaN(maxAltitude) {
 		b = append(b, `"maxAltitude":`...)
-		b = strconv.AppendFloat(b, s.MaxAltitudeScaled(), 'g', -1, 64)
+		b = strconv.AppendFloat(b, maxAltitude, 'g', -1, 64)
 		b = append(b, ',')
 	}
 


### PR DESCRIPTION
Some manufacturers may prefer using enhanced fields rather than ordinary field. For example, using EnhancedAltitude over Altitude. Since we were only using Altitude, the altitude data in some FIT files (one of which was produced by Garmin devices) could not be displayed properly. This applies for other enhanced field such as EnhancedSpeed, EnhancedAvgSpeed, etc.