### PR TITLE
feat: add product ids mapping

### DIFF
--- a/src/wasm/activity-service/manufacturers.json
+++ b/src/wasm/activity-service/manufacturers.json
@@ -12,6 +12,7 @@
       { "id": 2, "name": "x10" },
       { "id": 3, "name": "x6" },
       { "id": 4, "name": "Memory Belt" },
+      { "id": 5, "name": "Smart Belt" },
       { "id": 6, "name": "t6" },
       { "id": 7, "name": "t6c" },
       { "id": 8, "name": "t6d" },
@@ -140,11 +141,18 @@
       { "id": 1505, "name": "Rider 310" },
       { "id": 1508, "name": "Rider 530" },
       { "id": 1509, "name": "Rider 330" },
+      { "id": 1610, "name": "Rider 10" },
       { "id": 1703, "name": "Aero 60" },
       { "id": 1704, "name": "Rider 450" },
       { "id": 1706, "name": "Rider 410" },
       { "id": 1803, "name": "Rider 15" },
-      { "id": 1901, "name": "Rider 420" }
+      { "id": 1804, "name": "Rider 860" },
+      { "id": 1901, "name": "Rider 420" },
+      { "id": 1902, "name": "Rider S750" },
+      { "id": 2004, "name": "Rider 15 neo" },
+      { "id": 2101, "name": "Rider S500" },
+      { "id": 2103, "name": "Rider S800" },
+      { "id": 2203, "name": "Rider S750 SE" }
     ]
   },
   "289": {

--- a/src/wasm/activity-service/manufacturers.json
+++ b/src/wasm/activity-service/manufacturers.json
@@ -148,11 +148,11 @@
       { "id": 1803, "name": "Rider 15" },
       { "id": 1804, "name": "Rider 860" },
       { "id": 1901, "name": "Rider 420" },
-      { "id": 1902, "name": "Rider S750" },
+      { "id": 1902, "name": "Rider 750" },
       { "id": 2004, "name": "Rider 15 neo" },
       { "id": 2101, "name": "Rider S500" },
       { "id": 2103, "name": "Rider S800" },
-      { "id": 2203, "name": "Rider S750 SE" }
+      { "id": 2203, "name": "Rider 750 SE" }
     ]
   },
   "289": {

--- a/src/wasm/activity-service/manufacturers.json
+++ b/src/wasm/activity-service/manufacturers.json
@@ -149,10 +149,12 @@
       { "id": 1804, "name": "Rider 860" },
       { "id": 1901, "name": "Rider 420" },
       { "id": 1902, "name": "Rider 750" },
+      { "id": 2001, "name": "Rider 320" },
       { "id": 2004, "name": "Rider 15 neo" },
       { "id": 2101, "name": "Rider S500" },
       { "id": 2103, "name": "Rider S800" },
-      { "id": 2203, "name": "Rider 750 SE" }
+      { "id": 2203, "name": "Rider 750 SE" },
+      { "id": 2205, "name": "Rider 460" }
     ]
   },
   "289": {


### PR DESCRIPTION
Sources:
- Suunto: https://aspartnercontent.blob.core.windows.net/apizone/docs/DeviceProductIDs.pdf
- Bryton: typically use first 4 digits of UUID, it's shown on the app (it's perhaps the year and month of release), so we can get the ID by watching youtube on people connect their devices 😂
