### PR TITLE
bump FIT SDK for Go version to latest

### DIFF
--- a/src/wasm/activity-service/go.mod
+++ b/src/wasm/activity-service/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.23.0
 
 require (
-	github.com/muktihari/fit v0.24.2
+	github.com/muktihari/fit v0.24.3
 	github.com/muktihari/xmltokenizer v0.0.4
 	golang.org/x/text v0.18.0
 )

--- a/src/wasm/activity-service/go.mod
+++ b/src/wasm/activity-service/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.23.0
 
 require (
-	github.com/muktihari/fit v0.24.1
+	github.com/muktihari/fit v0.24.2
 	github.com/muktihari/xmltokenizer v0.0.4
 	golang.org/x/text v0.18.0
 )

--- a/src/wasm/activity-service/go.mod
+++ b/src/wasm/activity-service/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.23.0
 
 require (
-	github.com/muktihari/fit v0.23.6
+	github.com/muktihari/fit v0.24.1
 	github.com/muktihari/xmltokenizer v0.0.4
 	golang.org/x/text v0.18.0
 )

--- a/src/wasm/activity-service/go.sum
+++ b/src/wasm/activity-service/go.sum
@@ -1,7 +1,7 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/muktihari/fit v0.24.1 h1:BmahG6KFKc0HgTJC0SWuyCWsdkOgqiXbHQnokYlOfsw=
-github.com/muktihari/fit v0.24.1/go.mod h1:99RXB2OVc87XhcQzgHfUtCVE3VCJ4BvgmyWQI08MM4w=
+github.com/muktihari/fit v0.24.2 h1:9AKZFnlrlalapKkal/linKxTwVkkZlIUb9qkMR640mQ=
+github.com/muktihari/fit v0.24.2/go.mod h1:99RXB2OVc87XhcQzgHfUtCVE3VCJ4BvgmyWQI08MM4w=
 github.com/muktihari/xmltokenizer v0.0.4 h1:x4DZWvfcEAJR+iBPb8XeiWL1J15SY21bCaem76wmmjw=
 github.com/muktihari/xmltokenizer v0.0.4/go.mod h1:yTxhndrcpmZEPYqQGSN51MwkzPQgGSkRpqW5ZFBpdF0=
 golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 h1:e66Fs6Z+fZTbFBAxKfP3PALWBtpfqks2bwGcexMxgtk=

--- a/src/wasm/activity-service/go.sum
+++ b/src/wasm/activity-service/go.sum
@@ -1,9 +1,7 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/muktihari/fit v0.23.5 h1:Fu5JA29+oxH9qx4DjUQo+w1MNx5TqfBhrd6CdNHIBZo=
-github.com/muktihari/fit v0.23.5/go.mod h1:99RXB2OVc87XhcQzgHfUtCVE3VCJ4BvgmyWQI08MM4w=
-github.com/muktihari/fit v0.23.6 h1:wgZvTjO+10TOHLSePNuWk/VOQJKg14POEbB3WvlMe8Y=
-github.com/muktihari/fit v0.23.6/go.mod h1:99RXB2OVc87XhcQzgHfUtCVE3VCJ4BvgmyWQI08MM4w=
+github.com/muktihari/fit v0.24.1 h1:BmahG6KFKc0HgTJC0SWuyCWsdkOgqiXbHQnokYlOfsw=
+github.com/muktihari/fit v0.24.1/go.mod h1:99RXB2OVc87XhcQzgHfUtCVE3VCJ4BvgmyWQI08MM4w=
 github.com/muktihari/xmltokenizer v0.0.4 h1:x4DZWvfcEAJR+iBPb8XeiWL1J15SY21bCaem76wmmjw=
 github.com/muktihari/xmltokenizer v0.0.4/go.mod h1:yTxhndrcpmZEPYqQGSN51MwkzPQgGSkRpqW5ZFBpdF0=
 golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 h1:e66Fs6Z+fZTbFBAxKfP3PALWBtpfqks2bwGcexMxgtk=

--- a/src/wasm/activity-service/go.sum
+++ b/src/wasm/activity-service/go.sum
@@ -1,7 +1,7 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/muktihari/fit v0.24.2 h1:9AKZFnlrlalapKkal/linKxTwVkkZlIUb9qkMR640mQ=
-github.com/muktihari/fit v0.24.2/go.mod h1:99RXB2OVc87XhcQzgHfUtCVE3VCJ4BvgmyWQI08MM4w=
+github.com/muktihari/fit v0.24.3 h1:gNgPWyyzYMs5xWVBrSFZKmBbpfX9tnZOq7CEw+jsEfo=
+github.com/muktihari/fit v0.24.3/go.mod h1:99RXB2OVc87XhcQzgHfUtCVE3VCJ4BvgmyWQI08MM4w=
 github.com/muktihari/xmltokenizer v0.0.4 h1:x4DZWvfcEAJR+iBPb8XeiWL1J15SY21bCaem76wmmjw=
 github.com/muktihari/xmltokenizer v0.0.4/go.mod h1:yTxhndrcpmZEPYqQGSN51MwkzPQgGSkRpqW5ZFBpdF0=
 golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 h1:e66Fs6Z+fZTbFBAxKfP3PALWBtpfqks2bwGcexMxgtk=


### PR DESCRIPTION
Previous version of FIT SDK for Go has bug on component expansion logic, see https://github.com/muktihari/fit/pull/474 for details.