### PR TITLE
fix: aggregate session from laps

### DIFF
--- a/src/wasm/activity-service/activity/fit/fit.go
+++ b/src/wasm/activity-service/activity/fit/fit.go
@@ -256,7 +256,7 @@ func (s *DecodeEncoder) recalculateSummary(ses *activity.Session) {
 		records = records[pos:]
 	}
 	sesFromLaps := activity.NewSessionFromLaps(ses.Laps)
-	aggregator.Fill(ses, sesFromLaps.Session)
+	aggregator.Fill(ses.Session, sesFromLaps.Session)
 	ses.Summarize()
 }
 

--- a/src/wasm/activity-service/activity/session.go
+++ b/src/wasm/activity-service/activity/session.go
@@ -65,7 +65,7 @@ func NewSessionFromLaps(laps []Lap) Session {
 	)
 
 	for i := range laps {
-		aggregator.Aggregate(ses, laps[i].Lap)
+		aggregator.Aggregate(ses.Session, laps[i].Lap)
 	}
 
 	return ses


### PR DESCRIPTION
Currently, aggregator does not work if the struct has embedded struct/pointer, need to aggregate it directly.

I found this issue when trimming an activity and found out that some of session's fields are missing.