### PR TITLE
chore: update workflow for latest Go version

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,9 +29,8 @@ jobs:
 
       - name: Build Wasm & Web 🔧
         run: |
-          cp $(go env GOROOT)/misc/wasm/wasm_exec.js src/assets/wasm/wasm_exec.js
-
           npm ci
+          npm run init
           npm run build-wasm
           npm run build-only
           cp dist/index.html dist/404.html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,8 @@ jobs:
 
       - name: Build Wasm & Web 🔧
         run: |
-          GOROOT=$(go env GOROOT)
-          cp $GOROOT/misc/wasm/wasm_exec.js src/assets/wasm/wasm_exec.js
-
           npm ci
+          npm run init
           npm run build-wasm
           npm run build-only
           cp dist/index.html dist/404.html

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "init": "cp $(go env GOROOT)/misc/wasm/wasm_exec.js src/assets/wasm/wasm_exec.js",
+    "init": "cp $(go env GOROOT)/lib/wasm/wasm_exec.js src/assets/wasm/wasm_exec.js",
     "build-wasm": "cd src/wasm/activity-service && make build",
     "build-only": "vite build",
     "dev": "vite --host",


### PR DESCRIPTION
wasm_exec.js is now moved from `misc` to `lib`

cc: @raditzlawliet 