### PR TITLE
Publish latest dev

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,9 +29,8 @@ jobs:
 
       - name: Build Wasm & Web 🔧
         run: |
-          cp $(go env GOROOT)/misc/wasm/wasm_exec.js src/assets/wasm/wasm_exec.js
-
           npm ci
+          npm run init
           npm run build-wasm
           npm run build-only
           cp dist/index.html dist/404.html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,8 @@ jobs:
 
       - name: Build Wasm & Web 🔧
         run: |
-          GOROOT=$(go env GOROOT)
-          cp $GOROOT/misc/wasm/wasm_exec.js src/assets/wasm/wasm_exec.js
-
           npm ci
+          npm run init
           npm run build-wasm
           npm run build-only
           cp dist/index.html dist/404.html

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "init": "cp $(go env GOROOT)/misc/wasm/wasm_exec.js src/assets/wasm/wasm_exec.js",
+    "init": "cp $(go env GOROOT)/lib/wasm/wasm_exec.js src/assets/wasm/wasm_exec.js",
     "build-wasm": "cd src/wasm/activity-service && make build",
     "build-only": "vite build",
     "dev": "vite --host",

--- a/src/components/ToolDeviceSelector.vue
+++ b/src/components/ToolDeviceSelector.vue
@@ -39,12 +39,11 @@ import type { PropType } from 'vue'
         </v-select>
       </div>
       <div class="col-12">
-        <div class="row pt-2" v-show="isManualInputProduct">
-          <p v-show="!isManufacturerHasProduct">
-            Currently, we don't have a device mapping for
-            <strong>"{{ selected.manufacturerName }}"</strong>. We require a valid
-            <i>product_id</i> to generate a FIT file for the targeted device. Without a valid
-            <i>product_id</i>, the resulting FIT file may not be recognized by other platforms.
+        <div class="row pt-2" v-show="selected.isManualInputProduct">
+          <p>
+            We require a valid <i>product_id</i> to generate a FIT file for the targeted device.
+            Without a valid <i>product_id</i>, the resulting FIT file may not be recognized by other
+            platforms.
           </p>
           <div class="col">
             <label for="product" class="form-label sub-label"
@@ -85,9 +84,9 @@ export class DeviceOption {
   heading?: boolean = false
   manufacturerId?: number | undefined = undefined
   manufacturerName?: string = ''
-  isManualInputProduct?: boolean = false
   productId?: number | undefined = undefined
   productName?: string | undefined = undefined
+  isManualInputProduct: boolean = false
 
   constructor(data?: DeviceOption) {
     this.label = data?.label ?? '-- Please select a device --'
@@ -141,7 +140,8 @@ export default {
             manufacturerId: m.manufacturer.id,
             manufacturerName: m.manufacturer.name,
             productId: p.id,
-            productName: p.name
+            productName: p.name,
+            isManualInputProduct: false
           })
         }
       }
@@ -165,9 +165,10 @@ export default {
         dataSource.push(
           new DeviceOption({
             label: m.name,
-            heading: true,
+            heading: true, // only for separator label, unselectable.
             manufacturerId: m.id,
-            manufacturerName: m.name
+            manufacturerName: m.name,
+            isManualInputProduct: false
           })
         )
         m.products.forEach((p) =>
@@ -177,7 +178,8 @@ export default {
               manufacturerId: m.id,
               manufacturerName: m.name,
               productId: p.id,
-              productName: p.name
+              productName: p.name,
+              isManualInputProduct: false
             })
           )
         )
@@ -203,16 +205,6 @@ export default {
       })
       return map
     },
-    isManufacturerHasProduct(): boolean {
-      const m = this.manufacturerMap.get(this.selected.manufacturerId!)
-      if (m == undefined) return true
-      return m?.productMap.size > 0 ?? false
-    },
-    isManualInputProduct(): boolean {
-      if (this.selected.manufacturerId == undefined) return false
-      if (!this.isManufacturerHasProduct) return true
-      return this.selected.isManualInputProduct ?? false
-    },
     deviceMappingForGpxTcx(): Map<string, DeviceOption> {
       const map = new Map<string, DeviceOption>()
       this.manufacturers.forEach((m) => {
@@ -220,11 +212,12 @@ export default {
           map.set(
             `${m.name} ${p.name}`.toLowerCase(),
             new DeviceOption({
+              label: `${m.name} ${p.name}`,
               manufacturerId: m.id,
               manufacturerName: m.name,
               productId: p.id,
               productName: p.name,
-              label: `${m.name} ${p.name}`
+              isManualInputProduct: false
             })
           )
         })
@@ -233,6 +226,11 @@ export default {
     }
   },
   watch: {
+    selectedFileType: {
+      handler(fileType: FileType) {
+        if (fileType == FileType.FIT) this.updateSelectedByDeviceName(this.deviceName)
+      }
+    },
     deviceFromFitFile: {
       handler(device: DeviceOption) {
         this.selected = device
@@ -247,12 +245,8 @@ export default {
       handler(device: DeviceOption) {
         this.updateDeviceNameBySelected(device)
         if (isNaN(parseInt(device?.productId as unknown as string))) device.productId = undefined
+        if (device.isManualInputProduct) device.productId = undefined
         this.$emit('selectedDevice', device)
-      }
-    },
-    deviceName: {
-      handler(name: string) {
-        this.updateSelectedByDeviceName(name)
       }
     }
   },
@@ -268,9 +262,7 @@ export default {
     },
     updateSelectedByDeviceName(deviceName: string) {
       let device = this.deviceMappingForGpxTcx.get(deviceName.toLocaleLowerCase())
-      if (device == undefined) {
-        device = new DeviceOption({ label: deviceName })
-      }
+      if (device == undefined) device = new DeviceOption()
       this.selected = device
     }
   },

--- a/src/wasm/activity-service/activity/fit/wrapper.go
+++ b/src/wasm/activity-service/activity/fit/wrapper.go
@@ -1,9 +1,9 @@
 package fit
 
 import (
-	"github.com/muktihari/fit/factory"
 	"github.com/muktihari/fit/kit/datetime"
 	"github.com/muktihari/fit/profile/basetype"
+	"github.com/muktihari/fit/profile/factory"
 	"github.com/muktihari/fit/profile/filedef"
 	"github.com/muktihari/fit/profile/mesgdef"
 	"github.com/muktihari/fit/profile/untyped/fieldnum"

--- a/src/wasm/activity-service/go.mod
+++ b/src/wasm/activity-service/go.mod
@@ -1,16 +1,14 @@
 module github.com/openivity/activity-service
 
-go 1.22.0
-
-toolchain go1.23.0
+go 1.24.4
 
 require (
-	github.com/muktihari/fit v0.24.3
+	github.com/muktihari/fit v0.25.0
 	github.com/muktihari/xmltokenizer v0.0.4
-	golang.org/x/text v0.18.0
+	golang.org/x/text v0.26.0
 )
 
 require (
-	github.com/google/go-cmp v0.6.0
+	github.com/google/go-cmp v0.7.0
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
 )

--- a/src/wasm/activity-service/go.sum
+++ b/src/wasm/activity-service/go.sum
@@ -1,10 +1,10 @@
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/muktihari/fit v0.24.3 h1:gNgPWyyzYMs5xWVBrSFZKmBbpfX9tnZOq7CEw+jsEfo=
-github.com/muktihari/fit v0.24.3/go.mod h1:99RXB2OVc87XhcQzgHfUtCVE3VCJ4BvgmyWQI08MM4w=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/muktihari/fit v0.25.0 h1:WLO/B1u0t5PV2EJtc5j8r02kUlze7TqOvdfeO2jpwdA=
+github.com/muktihari/fit v0.25.0/go.mod h1:BGtO4GkWLPmnKz9keHvbtGDp8Ydwe7Wh1YK9OO6By84=
 github.com/muktihari/xmltokenizer v0.0.4 h1:x4DZWvfcEAJR+iBPb8XeiWL1J15SY21bCaem76wmmjw=
 github.com/muktihari/xmltokenizer v0.0.4/go.mod h1:yTxhndrcpmZEPYqQGSN51MwkzPQgGSkRpqW5ZFBpdF0=
 golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 h1:e66Fs6Z+fZTbFBAxKfP3PALWBtpfqks2bwGcexMxgtk=
 golang.org/x/exp v0.0.0-20240909161429-701f63a606c0/go.mod h1:2TbTHSBQa924w8M6Xs1QcRcFwyucIwBGpK1p2f1YFFY=
-golang.org/x/text v0.18.0 h1:XvMDiNzPAl0jr17s6W9lcaIhGUfUORdGCNsuLmPG224=
-golang.org/x/text v0.18.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
+golang.org/x/text v0.26.0 h1:P42AVeLghgTYr4+xUnTRKDMqpar+PtX7KWuNQL21L8M=
+golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=


### PR DESCRIPTION
### Build process updates:
* `.github/workflows/build-test.yml` and `.github/workflows/main.yml`: Removed redundant `wasm_exec.js` copy commands and added `npm run init` to the build steps. [[1]](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32L32-R33) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L32-R33)
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L6-R6): Updated the `init` script to copy `wasm_exec.js` from a new path (`lib/wasm` instead of `misc/wasm`).

### Refactoring in `ToolDeviceSelector.vue`:
* Simplified logic by removing unused computed properties (`isManufacturerHasProduct` and `isManualInputProduct`) and directly using `selected.isManualInputProduct`.
* Added default values for `isManualInputProduct` in `DeviceOption` class and initialization logic. [[1]](diffhunk://#diff-f104a0a259ed591bd8dc59f5c7fd93c6a7c72e25630a08538d7ccc9d4e7a7911L88-R89) [[2]](diffhunk://#diff-f104a0a259ed591bd8dc59f5c7fd93c6a7c72e25630a08538d7ccc9d4e7a7911L144-R144) [[3]](diffhunk://#diff-f104a0a259ed591bd8dc59f5c7fd93c6a7c72e25630a08538d7ccc9d4e7a7911L168-R171) [[4]](diffhunk://#diff-f104a0a259ed591bd8dc59f5c7fd93c6a7c72e25630a08538d7ccc9d4e7a7911L180-R182)
* Enhanced watchers for `selectedFileType` and `deviceFromFitFile` to handle updates more effectively. [[1]](diffhunk://#diff-f104a0a259ed591bd8dc59f5c7fd93c6a7c72e25630a08538d7ccc9d4e7a7911R229-R233) [[2]](diffhunk://#diff-f104a0a259ed591bd8dc59f5c7fd93c6a7c72e25630a08538d7ccc9d4e7a7911R248-L256)
* Refactored `updateSelectedByDeviceName` method to initialize `DeviceOption` without a label if no device mapping is found.

### Go dependency updates:
* [`src/wasm/activity-service/go.mod`](diffhunk://#diff-5aa67ec888ce5fedefa3fba19ea463df3a967211d840fb6862f23c63e41d9ac0L3-R12): Upgraded Go version to `1.24.4` and updated dependencies (`github.com/muktihari/fit` to `v0.25.0`, `golang.org/x/text` to `v0.26.0`, and `github.com/google/go-cmp` to `v0.7.0`).
* [`src/wasm/activity-service/activity/fit/wrapper.go`](diffhunk://#diff-bd973b42530bc8dd804b2766d882ecd5818fde07445d455322361d6e6434e178L4-R6): Changed import path for `factory` to `profile/factory` due to updates in the `github.com/muktihari/fit` library.