### PR TITLE
fix: issue 139 by bump FIT SDK version to latest

### DIFF
--- a/src/wasm/activity-service/go.mod
+++ b/src/wasm/activity-service/go.mod
@@ -3,9 +3,9 @@ module github.com/openivity/activity-service
 go 1.24.4
 
 require (
-	github.com/muktihari/fit v0.25.0
+	github.com/muktihari/fit v0.27.0
 	github.com/muktihari/xmltokenizer v0.0.4
-	golang.org/x/text v0.26.0
+	golang.org/x/text v0.32.0
 )
 
 require (

--- a/src/wasm/activity-service/go.sum
+++ b/src/wasm/activity-service/go.sum
@@ -1,10 +1,10 @@
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/muktihari/fit v0.25.0 h1:WLO/B1u0t5PV2EJtc5j8r02kUlze7TqOvdfeO2jpwdA=
-github.com/muktihari/fit v0.25.0/go.mod h1:BGtO4GkWLPmnKz9keHvbtGDp8Ydwe7Wh1YK9OO6By84=
+github.com/muktihari/fit v0.27.0 h1:m8AntMLqaYPoO18xkbR+Qp0/xIWpPROTZI0RBt0tmlQ=
+github.com/muktihari/fit v0.27.0/go.mod h1:IpJBARWj43cK7uFfDGqtRkKGxtWpg4N2m+wL5RI7/no=
 github.com/muktihari/xmltokenizer v0.0.4 h1:x4DZWvfcEAJR+iBPb8XeiWL1J15SY21bCaem76wmmjw=
 github.com/muktihari/xmltokenizer v0.0.4/go.mod h1:yTxhndrcpmZEPYqQGSN51MwkzPQgGSkRpqW5ZFBpdF0=
 golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 h1:e66Fs6Z+fZTbFBAxKfP3PALWBtpfqks2bwGcexMxgtk=
 golang.org/x/exp v0.0.0-20240909161429-701f63a606c0/go.mod h1:2TbTHSBQa924w8M6Xs1QcRcFwyucIwBGpK1p2f1YFFY=
-golang.org/x/text v0.26.0 h1:P42AVeLghgTYr4+xUnTRKDMqpar+PtX7KWuNQL21L8M=
-golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=
+golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
+golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=


### PR DESCRIPTION
Related issue: #139 due to default behaviour on FIT SDK Encoder that removes fields with invalid values. It actually has been removed in v0.27.0 (specifically by this PR https://github.com/muktihari/fit/pull/605) so bumping the version will fix the issue.